### PR TITLE
Downgrade faraday

### DIFF
--- a/instagram_basic_display_api.gemspec
+++ b/instagram_basic_display_api.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email = ['craig@sixoverground.com']
   s.homepage = 'https://github.com/sixoverground/instagram_basic_display_api'
 
-  s.add_runtime_dependency('faraday', '~> 0.17.3')
+  s.add_runtime_dependency('faraday', '~> 0.11.0')
   s.add_runtime_dependency('faraday_middleware', '~> 0.14.0')
 
   s.add_development_dependency('rspec', '~> 3.9', '>= 3.9.0')


### PR DESCRIPTION
We had to downgrade Faraday to get this gem to work with our app.

This gem requires a Faraday version greater than 0.17.  However, our Twitter gem won't allow a Faraday version greater than 0.11.  Rather than dealing with the risks involved with upgrading the twitter gem, this version is downgraded. 